### PR TITLE
fix: 3대3 미팅 API 세부 사항 수정 및 Swagger 설명 추가

### DIFF
--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/response/MeetingTeamInformationGetResponse.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/response/MeetingTeamInformationGetResponse.kt
@@ -1,10 +1,12 @@
 package uoslife.servermeeting.domain.meeting.application.response
 
+import uoslife.servermeeting.domain.meeting.domain.entity.enums.TeamType
 import uoslife.servermeeting.domain.user.domain.entity.enums.DepartmentNameType
 import uoslife.servermeeting.domain.user.domain.entity.enums.GenderType
 import uoslife.servermeeting.domain.user.domain.entity.enums.StudentType
 
 data class MeetingTeamInformationGetResponse(
+    val teamType: TeamType,
     val sex: GenderType,
     val teamUserList: List<UserProfile>,
     val informationFilter: String,

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/response/MeetingTeamUserListGetResponse.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/response/MeetingTeamUserListGetResponse.kt
@@ -1,6 +1,7 @@
 package uoslife.servermeeting.domain.meeting.application.response
 
 data class MeetingTeamUserListGetResponse(
+    val teamName: String,
     val userList: List<MeetingTeamUser>,
 )
 

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
@@ -1,6 +1,7 @@
 package uoslife.servermeeting.domain.meeting.application.rest
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.beans.factory.annotation.Qualifier
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*
 import uoslife.servermeeting.domain.meeting.application.request.MeetingTeamInformationUpdateRequest
 import uoslife.servermeeting.domain.meeting.application.response.MeetingTeamInformationGetResponse
 import uoslife.servermeeting.domain.meeting.application.response.MeetingTeamUserListGetResponse
+import uoslife.servermeeting.domain.meeting.domain.dao.UserTeamDao
 import uoslife.servermeeting.domain.meeting.domain.entity.enums.TeamType
 import uoslife.servermeeting.domain.meeting.domain.exception.*
 import uoslife.servermeeting.domain.meeting.domain.service.BaseMeetingService
@@ -23,9 +25,14 @@ import java.util.*
 class MeetingApi(
     @Qualifier("singleMeetingService") private val singleMeetingService: BaseMeetingService,
     @Qualifier("tripleMeetingService") private val tripleMeetingService: BaseMeetingService,
+    private val userTeamDao: UserTeamDao,
 ) {
 
     @Operation(summary = "미팅 팀 생성", description = "리더만 팀 생성 가능")
+    @ApiResponse(
+        responseCode = "201",
+        description = "1대1의 경우 빈 문자열을 반환, 3대3의 경우 팀 코드(A-Z0-9 4개)(String)를 반환",
+    )
     @PostMapping("/{teamType}/{isTeamLeader}/create")
     fun createMeetingTeam(
         @AuthenticationPrincipal userDetails: UserDetails,
@@ -47,7 +54,8 @@ class MeetingApi(
         return ResponseEntity.status(HttpStatus.CREATED).body(code)
     }
 
-    @Operation(summary = "미팅 팀 참가", description = "1대1의 경우 지원되지 않음. 1대1은 미팅 팀 생성 시 자동으로 참가됨. 3대3의 경우 팀 코드를 반환")
+    @Operation(summary = "미팅 팀 참가", description = "1대1의 경우 지원되지 않음. 1대1은 미팅 팀 생성 시 자동으로 참가됨")
+    @ApiResponse(responseCode = "204", description = "반환값 없음")
     @PostMapping("/{teamType}/join/{code}")
     fun joinMeetingTeam(
         @AuthenticationPrincipal userDetails: UserDetails,
@@ -66,6 +74,10 @@ class MeetingApi(
     }
 
     @Operation(summary = "팅 결성 대기 중 간에 미팅 팀 유저 리스트 조회", description = "1대1의 경우 지원되지 않음. 1대1은 팀 유저가 본인 단독")
+    @ApiResponse(
+        responseCode = "200",
+        description = "미팅 팀 유저 리스트 및 팀 이름(MeetingTeamUserListGetResponse) 반환",
+    )
     @GetMapping("/{teamType}/{code}/user/list")
     fun getMeetingTeamUserList(
         @AuthenticationPrincipal userDetails: UserDetails,
@@ -83,8 +95,8 @@ class MeetingApi(
         return ResponseEntity.status(HttpStatus.OK).body(meetingTeamUserListGetResponse)
     }
 
-    // preference는 상대에 대한 선호, Information은 본인에 대한 정보
     @Operation(summary = "미팅 팀 정보 기입", description = "팀의 정보를 기입함. 리더만 가능")
+    @ApiResponse(responseCode = "204", description = "반환값 없음")
     @PostMapping("/{teamType}/{isTeamLeader}/info")
     fun updateMeetingTeamInformation(
         @AuthenticationPrincipal userDetails: UserDetails,
@@ -122,21 +134,27 @@ class MeetingApi(
     }
 
     @Operation(summary = "미팅 팀 전체 정보 조회")
+    @ApiResponse(
+        responseCode = "200",
+        description = "미팅 팀 전체 정보(MeetingTeamInformationGetResponse) 반환",
+    )
     @GetMapping("/{teamType}/application/info")
     fun getMeetingTeamApplicationInformation(
         @AuthenticationPrincipal userDetails: UserDetails,
-        @PathVariable teamType: TeamType,
+        @PathVariable teamType: TeamType?,
     ): ResponseEntity<MeetingTeamInformationGetResponse> {
         val userUUID = UUID.fromString(userDetails.username)
 
         val meetingTeamInformationGetResponse = when (teamType) {
             TeamType.SINGLE -> singleMeetingService.getMeetingTeamInformation(userUUID)
             TeamType.TRIPLE -> tripleMeetingService.getMeetingTeamInformation(userUUID)
+            else -> autoFindTeamTypeAndGetTeamInformation(userUUID)
         }
         return ResponseEntity.status(HttpStatus.OK).body(meetingTeamInformationGetResponse)
     }
 
     @Operation(summary = "미팅 팀 삭제", description = "리더만 팀 삭제 가능")
+    @ApiResponse(responseCode = "204", description = "반환값 없음")
     @DeleteMapping("/{teamType}/{isTeamLeader}")
     fun deleteMeetingTeam(
         @AuthenticationPrincipal userDetails: UserDetails,
@@ -155,4 +173,16 @@ class MeetingApi(
         }
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
+
+    private fun autoFindTeamTypeAndGetTeamInformation(userUUID: UUID) =
+        (
+            userTeamDao.findUserTeamTypeByUserUUID(userUUID)
+                ?.let { userTeamType ->
+                    when (userTeamType) {
+                        TeamType.SINGLE -> singleMeetingService.getMeetingTeamInformation(userUUID)
+                        TeamType.TRIPLE -> tripleMeetingService.getMeetingTeamInformation(userUUID)
+                    }
+                }
+                ?: throw UserTeamNotFoundException()
+            )
 }

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
@@ -141,14 +141,13 @@ class MeetingApi(
     @GetMapping("/{teamType}/application/info")
     fun getMeetingTeamApplicationInformation(
         @AuthenticationPrincipal userDetails: UserDetails,
-        @PathVariable teamType: TeamType?,
+        @PathVariable teamType: TeamType,
     ): ResponseEntity<MeetingTeamInformationGetResponse> {
         val userUUID = UUID.fromString(userDetails.username)
 
         val meetingTeamInformationGetResponse = when (teamType) {
             TeamType.SINGLE -> singleMeetingService.getMeetingTeamInformation(userUUID)
             TeamType.TRIPLE -> tripleMeetingService.getMeetingTeamInformation(userUUID)
-            else -> autoFindTeamTypeAndGetTeamInformation(userUUID)
         }
         return ResponseEntity.status(HttpStatus.OK).body(meetingTeamInformationGetResponse)
     }
@@ -173,16 +172,4 @@ class MeetingApi(
         }
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
-
-    private fun autoFindTeamTypeAndGetTeamInformation(userUUID: UUID) =
-        (
-            userTeamDao.findUserTeamTypeByUserUUID(userUUID)
-                ?.let { userTeamType ->
-                    when (userTeamType) {
-                        TeamType.SINGLE -> singleMeetingService.getMeetingTeamInformation(userUUID)
-                        TeamType.TRIPLE -> tripleMeetingService.getMeetingTeamInformation(userUUID)
-                    }
-                }
-                ?: throw UserTeamNotFoundException()
-            )
 }

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
@@ -55,7 +55,7 @@ class MeetingApi(
     }
 
     @Operation(summary = "미팅 팀 참가", description = "1대1의 경우 지원되지 않음. 1대1은 미팅 팀 생성 시 자동으로 참가됨")
-    @ApiResponse(responseCode = "204", description = "반환값 없음")
+    @ApiResponse(responseCode = "204", description = "isJoin true일 경우, 팀 참가 및 null 반환, false일 경우, 팀 참가하지 않고 팀 정보 반환")
     @PostMapping("/{teamType}/join/{code}")
     fun joinMeetingTeam(
         @AuthenticationPrincipal userDetails: UserDetails,

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
@@ -61,16 +61,16 @@ class MeetingApi(
         @AuthenticationPrincipal userDetails: UserDetails,
         @PathVariable teamType: TeamType,
         @PathVariable code: String,
-    ): ResponseEntity<Unit> {
+        @RequestParam isJoin: Boolean,
+    ): ResponseEntity<MeetingTeamUserListGetResponse?> {
         val userUUID = UUID.fromString(userDetails.username)
 
         if (teamType == TeamType.SINGLE) {
             throw InSingleMeetingTeamNoJoinTeamException()
         }
 
-        tripleMeetingService.joinMeetingTeam(userUUID, code)
-
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        val meetingTeamUserListGetResponse = tripleMeetingService.joinMeetingTeam(userUUID, code, isJoin)
+        return ResponseEntity.ok(meetingTeamUserListGetResponse)
     }
 
     @Operation(summary = "팅 결성 대기 중 간에 미팅 팀 유저 리스트 조회", description = "1대1의 경우 지원되지 않음. 1대1은 팀 유저가 본인 단독")

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*
 import uoslife.servermeeting.domain.meeting.application.request.MeetingTeamInformationUpdateRequest
 import uoslife.servermeeting.domain.meeting.application.response.MeetingTeamInformationGetResponse
 import uoslife.servermeeting.domain.meeting.application.response.MeetingTeamUserListGetResponse
-import uoslife.servermeeting.domain.meeting.domain.dao.UserTeamDao
 import uoslife.servermeeting.domain.meeting.domain.entity.enums.TeamType
 import uoslife.servermeeting.domain.meeting.domain.exception.*
 import uoslife.servermeeting.domain.meeting.domain.service.BaseMeetingService

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/application/rest/MeetingApi.kt
@@ -25,7 +25,6 @@ import java.util.*
 class MeetingApi(
     @Qualifier("singleMeetingService") private val singleMeetingService: BaseMeetingService,
     @Qualifier("tripleMeetingService") private val tripleMeetingService: BaseMeetingService,
-    private val userTeamDao: UserTeamDao,
 ) {
 
     @Operation(summary = "미팅 팀 생성", description = "리더만 팀 생성 가능")

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/InformationUpdateDao.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/InformationUpdateDao.kt
@@ -2,11 +2,11 @@ package uoslife.servermeeting.domain.meeting.domain.dao
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.transaction.Transactional
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Repository
 import uoslife.servermeeting.domain.meeting.domain.entity.MeetingTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.QInformation.information
 
-@Service
+@Repository
 @Transactional
 class InformationUpdateDao(private val queryFactory: JPAQueryFactory) {
     fun updateInformationByMeetingTeam(

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/PreferenceUpdateDao.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/PreferenceUpdateDao.kt
@@ -2,11 +2,11 @@ package uoslife.servermeeting.domain.meeting.domain.dao
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.transaction.Transactional
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Repository
 import uoslife.servermeeting.domain.meeting.domain.entity.MeetingTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.QPreference.preference
 
-@Service
+@Repository
 @Transactional
 class PreferenceUpdateDao(
     private val queryFactory: JPAQueryFactory,

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/UserTeamDao.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/UserTeamDao.kt
@@ -65,12 +65,6 @@ class UserTeamDao(
             .fetchOne()
     }
 
-    fun findUserTeamTypeByUserUUID(userUUID: UUID): TeamType? {
-        return queryFactory.selectFrom(userTeam)
-            .where(userTeam.user.id.eq(userUUID))
-            .fetchOne()?.type
-    }
-
     fun countByTeam(meetingTeam: MeetingTeam): Int {
         return queryFactory.selectFrom(userTeam)
             .where(userTeam.team.eq(meetingTeam))

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/UserTeamDao.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/UserTeamDao.kt
@@ -9,6 +9,7 @@ import uoslife.servermeeting.domain.meeting.domain.entity.QUserTeam.userTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.UserTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.enums.TeamType
 import uoslife.servermeeting.domain.user.domain.entity.User
+import java.util.UUID
 
 @Service
 @Transactional
@@ -33,11 +34,12 @@ class UserTeamDao(
             .fetchOne()
     }
 
-    fun findByUserWithMeetingTeam(user: User): UserTeam? {
+    fun findByUserWithMeetingTeam(user: User, teamType: TeamType): UserTeam? {
         return queryFactory.selectFrom(userTeam)
             .join(userTeam.team)
             .fetchJoin()
             .where(userTeam.user.eq(user))
+            .where(userTeam.type.eq(teamType))
             .fetchOne()
     }
 
@@ -61,6 +63,12 @@ class UserTeamDao(
             .fetchJoin()
             .where(userTeam.team.eq(meetingTeam), userTeam.isLeader.eq(isLeader))
             .fetchOne()
+    }
+
+    fun findUserTeamTypeByUserUUID(userUUID: UUID): TeamType? {
+        return queryFactory.selectFrom(userTeam)
+            .where(userTeam.user.id.eq(userUUID))
+            .fetchOne()?.type
     }
 
     fun countByTeam(meetingTeam: MeetingTeam): Int {

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/UserTeamDao.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/UserTeamDao.kt
@@ -3,14 +3,14 @@ package uoslife.servermeeting.domain.meeting.domain.dao
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jakarta.persistence.EntityManager
 import jakarta.transaction.Transactional
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Repository
 import uoslife.servermeeting.domain.meeting.domain.entity.MeetingTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.QUserTeam.userTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.UserTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.enums.TeamType
 import uoslife.servermeeting.domain.user.domain.entity.User
 
-@Service
+@Repository
 @Transactional
 class UserTeamDao(
     private val queryFactory: JPAQueryFactory,

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/UserTeamDao.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/dao/UserTeamDao.kt
@@ -9,7 +9,6 @@ import uoslife.servermeeting.domain.meeting.domain.entity.QUserTeam.userTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.UserTeam
 import uoslife.servermeeting.domain.meeting.domain.entity.enums.TeamType
 import uoslife.servermeeting.domain.user.domain.entity.User
-import java.util.UUID
 
 @Service
 @Transactional

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/BaseMeetingService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/BaseMeetingService.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 interface BaseMeetingService {
     fun createMeetingTeam(userUUID: UUID, name: String? = null): String?
-    fun joinMeetingTeam(userUUID: UUID, code: String)
+    fun joinMeetingTeam(userUUID: UUID, code: String, isJoin: Boolean): MeetingTeamUserListGetResponse?
     fun getMeetingTeamUserList(userUUID: UUID, code: String): MeetingTeamUserListGetResponse
     fun updateMeetingTeamInformation(
         userUUID: UUID,

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/SingleMeetingService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/SingleMeetingService.kt
@@ -56,7 +56,7 @@ class SingleMeetingService(
         return ""
     }
 
-    override fun joinMeetingTeam(userUUID: UUID, code: String) {
+    override fun joinMeetingTeam(userUUID: UUID, code: String, isJoin: Boolean): MeetingTeamUserListGetResponse? {
         throw InSingleMeetingTeamNoJoinTeamException()
     }
 

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/SingleMeetingService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/SingleMeetingService.kt
@@ -74,7 +74,7 @@ class SingleMeetingService(
     ) {
         val user = userRepository.findByIdOrNull(userUUID) ?: throw UserNotFoundException()
 
-        val userTeam = userTeamDao.findByUserWithMeetingTeam(user) ?: throw UserTeamNotFoundException()
+        val userTeam = userTeamDao.findByUserWithMeetingTeam(user, TeamType.SINGLE) ?: throw UserTeamNotFoundException()
         val meetingTeam =
             meetingTeamRepository.findByIdOrNull(userTeam.team.id!!) ?: throw MeetingTeamNotFoundException()
 
@@ -89,7 +89,7 @@ class SingleMeetingService(
     override fun getMeetingTeamInformation(userUUID: UUID): MeetingTeamInformationGetResponse {
         val user = userRepository.findByIdOrNull(userUUID) ?: throw UserNotFoundException()
 
-        val userTeam = userTeamDao.findByUserWithMeetingTeam(user) ?: throw UserTeamNotFoundException()
+        val userTeam = userTeamDao.findByUserWithMeetingTeam(user, TeamType.SINGLE) ?: throw UserTeamNotFoundException()
         val meetingTeam =
             meetingTeamRepository.findByIdOrNull(userTeam.team.id!!) ?: throw MeetingTeamNotFoundException()
 
@@ -102,7 +102,7 @@ class SingleMeetingService(
     override fun deleteMeetingTeam(userUUID: UUID) {
         val user = userRepository.findByIdOrNull(userUUID) ?: throw UserNotFoundException()
 
-        val userTeam = userTeamDao.findByUserWithMeetingTeam(user) ?: throw UserTeamNotFoundException()
+        val userTeam = userTeamDao.findByUserWithMeetingTeam(user, TeamType.SINGLE) ?: throw UserTeamNotFoundException()
         val meetingTeam =
             meetingTeamRepository.findByIdOrNull(userTeam.team.id!!) ?: throw MeetingTeamNotFoundException()
 
@@ -118,6 +118,7 @@ class SingleMeetingService(
         val userBirthYear: Int = user.birthYear as Int
         return MeetingTeamInformationGetResponse(
             sex = user.gender,
+            teamType = TeamType.SINGLE,
             informationDistance = information.distanceInfo,
             informationFilter = information.filterInfo,
             informationMeetingTime = information.meetingTime,

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingService.kt
@@ -202,7 +202,8 @@ class TripleMeetingService(
         return code
     }
 
-    private fun toMeetingTeamUserListGetResponse(teamName: String, userList: List<User>): MeetingTeamUserListGetResponse {
+    private fun toMeetingTeamUserListGetResponse(teamName: String, userList: List<User>):
+        MeetingTeamUserListGetResponse {
         val currentYear: Int = LocalDate.now().year
 
         return MeetingTeamUserListGetResponse(

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingService.kt
@@ -97,7 +97,7 @@ class TripleMeetingService(
     ) {
         val user = userRepository.findByIdOrNull(userUUID) ?: throw UserNotFoundException()
 
-        val userTeam = userTeamDao.findByUserWithMeetingTeam(user) ?: throw UserTeamNotFoundException()
+        val userTeam = userTeamDao.findByUserWithMeetingTeam(user, TeamType.TRIPLE) ?: throw UserTeamNotFoundException()
         val meetingTeam =
             meetingTeamRepository.findByIdOrNull(userTeam.team.id!!) ?: throw MeetingTeamNotFoundException()
 
@@ -112,7 +112,7 @@ class TripleMeetingService(
     override fun getMeetingTeamInformation(userUUID: UUID): MeetingTeamInformationGetResponse {
         val user = userRepository.findByIdOrNull(userUUID) ?: throw UserNotFoundException()
 
-        val userTeam = userTeamDao.findByUserWithMeetingTeam(user) ?: throw UserTeamNotFoundException()
+        val userTeam = userTeamDao.findByUserWithMeetingTeam(user, TeamType.TRIPLE) ?: throw UserTeamNotFoundException()
         val meetingTeam = userTeam.team
         val userList = userTeamDao.findByTeam(meetingTeam).map { it.user!! }
 
@@ -125,7 +125,7 @@ class TripleMeetingService(
     override fun deleteMeetingTeam(userUUID: UUID) {
         val user = userRepository.findByIdOrNull(userUUID) ?: throw UserNotFoundException()
 
-        val userTeam = userTeamDao.findByUserWithMeetingTeam(user) ?: throw UserTeamNotFoundException()
+        val userTeam = userTeamDao.findByUserWithMeetingTeam(user, TeamType.TRIPLE) ?: throw UserTeamNotFoundException()
         val meetingTeam = userTeam.team
 
         meetingTeamRepository.deleteById(meetingTeam.id!!)
@@ -269,6 +269,7 @@ class TripleMeetingService(
         val currentYear: Int = LocalDate.now().year
 
         return MeetingTeamInformationGetResponse(
+            teamType = TeamType.TRIPLE,
             sex = gender,
             informationDistance = information.distanceInfo,
             informationFilter = information.filterInfo,

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingService.kt
@@ -84,7 +84,7 @@ class TripleMeetingService(
         isUserInTeam(user, meetingTeam)
 
         val userList = userTeamDao.findByTeam(meetingTeam).map { it.user!! }
-        return toMeetingTeamUserListGetResponse(userList)
+        return toMeetingTeamUserListGetResponse(meetingTeam.name!!, userList)
     }
 
     override fun updateMeetingTeamInformation(
@@ -196,10 +196,11 @@ class TripleMeetingService(
         return code
     }
 
-    private fun toMeetingTeamUserListGetResponse(userList: List<User>): MeetingTeamUserListGetResponse {
+    private fun toMeetingTeamUserListGetResponse(teamName: String, userList: List<User>): MeetingTeamUserListGetResponse {
         val currentYear: Int = LocalDate.now().year
 
         return MeetingTeamUserListGetResponse(
+            teamName = teamName,
             userList.map {
                 MeetingTeamUser(
                     nickname = it.nickname,

--- a/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingService.kt
@@ -60,7 +60,7 @@ class TripleMeetingService(
         return code
     }
 
-    override fun joinMeetingTeam(userUUID: UUID, code: String) {
+    override fun joinMeetingTeam(userUUID: UUID, code: String, isJoin: Boolean): MeetingTeamUserListGetResponse? {
         val user = userRepository.findByIdOrNull(userUUID) ?: throw UserNotFoundException()
 
         isTeamCodeValid(code)
@@ -72,7 +72,13 @@ class TripleMeetingService(
         isTeamFull(meetingTeam)
         isUserSameGenderWithTeamLeader(user, leaderUserTeam.user!!)
 
-        userTeamDao.saveUserTeam(meetingTeam, user, false, TeamType.TRIPLE)
+        return if (isJoin) {
+            userTeamDao.saveUserTeam(meetingTeam, user, false, TeamType.TRIPLE)
+            null
+        } else {
+            val userList = userTeamDao.findByTeam(meetingTeam).map { it.user!! }
+            toMeetingTeamUserListGetResponse(meetingTeam.name!!, userList)
+        }
     }
 
     override fun getMeetingTeamUserList(userUUID: UUID, code: String): MeetingTeamUserListGetResponse {

--- a/src/test/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/SingleMeetingServiceTest.kt
+++ b/src/test/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/SingleMeetingServiceTest.kt
@@ -56,7 +56,7 @@ class SingleMeetingServiceTest : SingleMeetingTest() {
         val code = singleMeetingService.createMeetingTeam(user.id!!, "")
 
         // when & then
-        assertThatThrownBy { singleMeetingService.joinMeetingTeam(user.id!!, code!!) }
+        assertThatThrownBy { singleMeetingService.joinMeetingTeam(user.id!!, code!!, true) }
             .isInstanceOf(InSingleMeetingTeamNoJoinTeamException::class.java)
     }
 

--- a/src/test/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/SingleMeetingServiceTest.kt
+++ b/src/test/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/SingleMeetingServiceTest.kt
@@ -132,7 +132,7 @@ class SingleMeetingServiceTest : SingleMeetingTest() {
         )
 
         // then
-        val userTeam = userTeamDao.findByUserWithMeetingTeam(user)
+        val userTeam = userTeamDao.findByUserWithMeetingTeam(user, TeamType.SINGLE)
         val information = informationRepository.findByMeetingTeam(meetingTeam) ?: throw InformationNotFoundException()
         val preference = preferenceRepository.findByMeetingTeam(meetingTeam) ?: throw PreferenceNotFoundException()
         assertThat(userTeam).isNotNull
@@ -193,6 +193,7 @@ class SingleMeetingServiceTest : SingleMeetingTest() {
         // then
         assertThat(information).isNotNull
         assertThat(information.sex).isEqualTo(GenderType.FEMALE)
+        assertThat(information.teamType).isEqualTo(TeamType.SINGLE)
         assertThat(information.informationDistance).isEqualTo("0")
         assertThat(information.informationFilter).isEqualTo("1")
         assertThat(information.informationMeetingTime).isEqualTo("0010")

--- a/src/test/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingServiceTest.kt
+++ b/src/test/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingServiceTest.kt
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import uoslife.servermeeting.domain.meeting.domain.common.TripleMeetingTest
+import uoslife.servermeeting.domain.meeting.domain.entity.enums.TeamType
 import uoslife.servermeeting.domain.meeting.domain.exception.*
 import uoslife.servermeeting.domain.user.domain.entity.enums.GenderType
 import uoslife.servermeeting.domain.user.domain.exception.UserNotFoundException
@@ -257,6 +258,8 @@ class TripleMeetingServiceTest : TripleMeetingTest() {
 
         // then
         val meetingInfo = tripleMeetingService.getMeetingTeamInformation(user1.id!!)
+        assertThat(meetingInfo.sex).isEqualTo(GenderType.FEMALE)
+        assertThat(meetingInfo.teamType).isEqualTo(TeamType.TRIPLE)
         assertThat(meetingInfo.informationDistance).isEqualTo("0001")
         assertThat(meetingInfo.informationFilter).isEqualTo("0010")
         assertThat(meetingInfo.informationMeetingTime).isEqualTo("0011")

--- a/src/test/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingServiceTest.kt
+++ b/src/test/kotlin/uoslife/servermeeting/domain/meeting/domain/service/impl/TripleMeetingServiceTest.kt
@@ -211,6 +211,7 @@ class TripleMeetingServiceTest : TripleMeetingTest() {
         teamAgeList.sortedBy { it }
 
         assertThat(teamUserList.userList.size).isEqualTo(3)
+        assertThat(teamUserList.teamName).isEqualTo("abcd")
         assertThat(teamAgeList[1]!! - teamAgeList[0]!!).isLessThan(3)
     }
 


### PR DESCRIPTION
### Difference
-  Meeting Team 전체 정보 조회 시 TeamType 추가
- Join하기 전에 한번 확인을 위해 팀 이름 및 현재 인원 정보 필요 isJoin을 파라미터로 받아서 바로 참가하지 않고 팀 정보 확인
- 팅 결성 대기 중에 팅 이름을 추가로 내려보내기
- Swagger에서 응답 타입 명확하지 않은 것 추가
- UserTeam 조회 시 Single Triple 명시하여 명확하게 정의