### PR TITLE
feat: docker-compose 환경에서 redis container도 함께 실행시킬 수 있도록 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
     postgres:
         image: postgres
+        restart: always
         ports:
             - "5432:5432"
         container_name: postgres
@@ -10,6 +11,14 @@ services:
             POSTGRES_USER: server-meeting
             POSTGRES_PASSWORD: server-meeting
             POSTGRES_DB: server-meeting
+
+    redis:
+        image: redis
+        restart: always
+        command: redis-server --port 6379
+        hostname: redis
+        ports:
+            - "6379:6379"
 
     application:
         build:
@@ -23,3 +32,4 @@ services:
             SPRING_DATASOURCE_PASSWORD: server-meeting
         depends_on:
             - postgres
+            - redis


### PR DESCRIPTION
## 추가사항
- docker-compose.yml에 redis 컨테이너를 함께 실행시키도록 추가했습니다.
- spring application에서 redis에 연결하도록 설정했습니다.

## 변동사항
- redis 및 postgres 컨테이너에 restart 옵션을 추가했습니다.

