### PR TITLE
fix: h2-console 설정 제거

### DIFF
--- a/src/main/kotlin/uoslife/servermeeting/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/uoslife/servermeeting/global/config/SecurityConfig.kt
@@ -130,7 +130,6 @@ class SecurityConfig(
                     "/v3/api-docs/**",
                     "/swagger-resources/**",
                 )
-                .requestMatchers(PathRequest.toH2Console())
         }
     }
 


### PR DESCRIPTION
# 설명
서버에서 DB API 실행하면 
```No qualifying bean of type 'org.springframework.boot.autoconfigure.h2.H2ConsoleProperties' available```
해당 에러가 떠서 
SecurityConfig에 h2 관련 항목 삭제하려고 합니다.
쓰시는 거면 머지 말고 close 해주세요