### PR TITLE
fix: 시대생 localhost 서버에서 실제 시대생 서버로 url 변경

### DIFF
--- a/src/main/kotlin/uoslife/servermeeting/global/auth/api/AuthApi.kt
+++ b/src/main/kotlin/uoslife/servermeeting/global/auth/api/AuthApi.kt
@@ -70,7 +70,7 @@ class AuthApi(
         return ResponseEntity.ok().body(tokenResponse)
     }
 
-    @Operation(summary = "시대생 앱과 마이그레이션")
+    @Operation(summary = "시대생 토큰으로 회원가입(or 로그인)")
     @ApiResponses(
         value =
             [
@@ -81,7 +81,7 @@ class AuthApi(
                 ),
                 ApiResponse(
                     responseCode = "400",
-                    description = "이미 마이그레이션 되어있음",
+                    description = "이미 회원가입 되어있음",
                     content =
                         [
                             Content(
@@ -96,10 +96,10 @@ class AuthApi(
                 ),
             ]
     )
-    @PostMapping("/uos/migrate")
-    fun migrateUOS(request: HttpServletRequest): ResponseEntity<TokenResponse> {
+    @PostMapping("/uos/signUp")
+    fun signUpUOS(request: HttpServletRequest): ResponseEntity<TokenResponse> {
         val bearerToken: String = request.getHeader("Authorization")
-        val tokenResponse: TokenResponse = authService.migrateFromUoslife(bearerToken)
+        val tokenResponse: TokenResponse = authService.signUpFromUoslife(bearerToken)
 
         return ResponseEntity.ok().body(tokenResponse)
     }
@@ -145,10 +145,10 @@ class AuthApi(
                 ),
             ]
     )
-    @PostMapping("/uos/login")
-    fun login(request: HttpServletRequest): ResponseEntity<TokenResponse> {
+    @PostMapping("/uos/signIn")
+    fun signIn(request: HttpServletRequest): ResponseEntity<TokenResponse> {
         val bearerToken: String = request.getHeader("Authorization")
-        val tokenResponse: TokenResponse = authService.login(bearerToken)
+        val tokenResponse: TokenResponse = authService.signIn(bearerToken)
 
         return ResponseEntity.ok().body(tokenResponse)
     }

--- a/src/main/kotlin/uoslife/servermeeting/global/auth/dto/response/UserProfileVO.kt
+++ b/src/main/kotlin/uoslife/servermeeting/global/auth/dto/response/UserProfileVO.kt
@@ -4,10 +4,10 @@ import java.time.LocalDate
 
 data class UserProfileVO(
     val id: Long?,
-    val name: String,
+    val name: String, // 이것들만 사용
     val nickname: String?,
     val birthday: LocalDate?,
-    val phone: String,
+    val phone: String, // 이것들만 사용
     val avatarUrl: String?,
     var isVerified: Boolean? = null,
     var degree: String? = null,

--- a/src/main/kotlin/uoslife/servermeeting/global/auth/service/AuthService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/global/auth/service/AuthService.kt
@@ -44,7 +44,7 @@ class AuthService(
 
     // 시대생 앱 토큰으로 요청 시 회원가입 후 토큰 발급
     @Transactional
-    fun migrateFromUoslife(bearerToken: String): TokenResponse {
+    fun signUpFromUoslife(bearerToken: String): TokenResponse {
         // rebuild-server에서 유저 데이터 가져오기
         val userProfileVOFromUoslife: UserProfileVO = getUserProfileFromUoslife(bearerToken)
 
@@ -98,6 +98,7 @@ class AuthService(
     }
 
     fun login(bearerToken: String): TokenResponse {
+    fun signIn(bearerToken: String): TokenResponse {
         // rebuild-server에서 유저 데이터 가져오기
         val userProfileVOFromUoslife: UserProfileVO = getUserProfileFromUoslife(bearerToken)
 

--- a/src/main/kotlin/uoslife/servermeeting/global/auth/service/AuthService.kt
+++ b/src/main/kotlin/uoslife/servermeeting/global/auth/service/AuthService.kt
@@ -48,12 +48,8 @@ class AuthService(
         // rebuild-server에서 유저 데이터 가져오기
         val userProfileVOFromUoslife: UserProfileVO = getUserProfileFromUoslife(bearerToken)
 
-        // 이미 회원가입 되어 있다면 예외 발생
-        if (userRepository.existsByPhoneNumber(userProfileVOFromUoslife.phone))
-            throw UserAlreadyExistsException()
-
         // 회원가입 진행
-        val savedUser: User = saveUser(userProfileVOFromUoslife)
+        val savedUser: User = createOrGetUser(userProfileVOFromUoslife)
 
         // 토큰 발급
         val tokenResponse: TokenResponse = tokenProvider.getTokenByUser(savedUser)
@@ -62,7 +58,7 @@ class AuthService(
 
     private fun getUserProfileFromUoslife(bearerToken: String): UserProfileVO {
         val restTemplate: RestTemplate = RestTemplate()
-        val url: String = "http://localhost:8081/core/users"
+        val url: String = "https://api.uoslife.com/core/users"
 
         // request header
         val headers: MultiValueMap<String, String> = LinkedMultiValueMap()
@@ -83,7 +79,14 @@ class AuthService(
         return userProfileVO
     }
 
-    private fun saveUser(userProfileVO: UserProfileVO): User {
+    private fun createOrGetUser(userProfileVO: UserProfileVO): User {
+        // DB에 검색해서 있으면 가져오고 없으면 생성(회원가입)
+        val user: User = userRepository.findByPhoneNumber(userProfileVO.phone) ?: createUser(userProfileVO)
+
+        return user
+    }
+
+    private fun createUser(userProfileVO: UserProfileVO): User {
         val user: User =
             User(
                 id = UUID.randomUUID(),
@@ -91,13 +94,11 @@ class AuthService(
                 name = userProfileVO.name
             )
         user.userPersonalInformation.university = University.UOS
-
         val savedUser: User = userRepository.save(user)
 
-        return savedUser
+        return user
     }
 
-    fun login(bearerToken: String): TokenResponse {
     fun signIn(bearerToken: String): TokenResponse {
         // rebuild-server에서 유저 데이터 가져오기
         val userProfileVOFromUoslife: UserProfileVO = getUserProfileFromUoslife(bearerToken)

--- a/src/main/kotlin/uoslife/servermeeting/user/repository/UserRepository.kt
+++ b/src/main/kotlin/uoslife/servermeeting/user/repository/UserRepository.kt
@@ -6,6 +6,5 @@ import uoslife.servermeeting.user.entity.User
 
 interface UserRepository : JpaRepository<User, UUID> {
     fun findByEmail(email: String): User?
-    fun existsByPhoneNumber(phoneNumber: String): Boolean
     fun findByPhoneNumber(phoneNumber: String): User?
 }


### PR DESCRIPTION
# 개요
- 시대생 localhost 서버에서 실제 시대생 서버로 url 변경
- 로그인, 회원가입 메서드명 변경
- 불필요한 변수 삭제

# 상세 설명
<img width="698" alt="Screenshot 2024-03-25 at 6 20 25 PM" src="https://github.com/uoslife/server-meeting/assets/15906109/be96dc4a-022d-4539-b0fb-a957107a31d3">
시대생 서버를 로컬에서 테스트 했던 걸 실제 시대생 서버(api.uoslife.com)으로 변경했음.